### PR TITLE
replace o with O, x with X, and The winner is

### DIFF
--- a/ada-project-docs/optional-enhancements.md
+++ b/ada-project-docs/optional-enhancements.md
@@ -21,7 +21,7 @@ There are tests provided for this optional enhancement!
 Unskip these tests to verify if the reset button resets the grid. The provided tests check for:
 
 - When the reset button (with the text "Reset Game") is clicked, the grid should go back to blank squares. It selects all the `<button class="square"></button>` elements and verifies that they have no text.
-- Immediately after the reset button is clicked, the text "Winner is o" or "Winner is x" should not appear.
+- Immediately after the reset button is clicked, the text "The winner is O" or "The winner is X" should not appear.
 
 ## Deploy on the Web
 

--- a/ada-project-docs/testing-requirements.md
+++ b/ada-project-docs/testing-requirements.md
@@ -90,7 +90,7 @@ The wave 1 tests exist in the files:
 The wave 1 tests verify that:
 
 - The `Square` and `Board` components are rendered and present on the screen
-- The `Square` component displays either an `"x"`, an `"O"`, or an empty string `""`.
+- The `Square` component displays either an `"X"`, an `"O"`, or an empty string `""`.
 
 ## Wave 2
 
@@ -119,5 +119,5 @@ They are skipped by default. Modify the syntax to unskip them.
 
 The wave 3 tests verify that:
 
-- If x wins, the text "Winner is x" appears
-- If o wins, the text "Winner is o" appears
+- If X wins, the text "The winner is X" appears
+- If O wins, the text "The winner is O" appears

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -39,21 +39,21 @@ describe('App', () => {
     expect(header).toBeInTheDocument();
   });
 
-  test('Clicking on a grid button changes the text on it to an "x"', () => {
+  test('Clicking on a grid button changes the text on it to an "X"', () => {
     // Arrange
     const { container } = render(<App />);
 
     // Act-assert
-    clickButtonAndVerifyResult(container, 0, 'x');
+    clickButtonAndVerifyResult(container, 0, 'X');
   });
 
-  test('Clicking on the 1st button makes it an "x" and the 2nd an "o"', () => {
+  test('Clicking on the 1st button makes it an "X" and the 2nd an "O"', () => {
     // Arrange
     const { container } = render(<App />);
 
     //Act-Assert
-    clickButtonAndVerifyResult(container, 0, 'x');
-    clickButtonAndVerifyResult(container, 8, 'o');
+    clickButtonAndVerifyResult(container, 0, 'X');
+    clickButtonAndVerifyResult(container, 8, 'O');
   });
 
   test('clicking on the same square twice doesn\'t change things', () => {
@@ -64,42 +64,42 @@ describe('App', () => {
     let buttons = container.querySelectorAll('.grid button');
     fireEvent.click(buttons[0]);
 
-    // after the click there should be a square with an "x"
-    let clickedButton = screen.getByText('x');
+    // after the click there should be a square with an "X"
+    let clickedButton = screen.getByText('X');
     expect(clickedButton).toBeInTheDocument();
 
     buttons = container.querySelectorAll('.grid button');
     fireEvent.click(buttons[0]);
 
     // Assert
-    // after the 2nd click there should still be a square with an "x"
-    clickedButton = screen.getByText('x');
+    // after the 2nd click there should still be a square with an "X"
+    clickedButton = screen.getByText('X');
     expect(clickedButton).toBeInTheDocument();
 
 
-    const xButtons = screen.queryAllByText('x');
+    const xButtons = screen.queryAllByText('X');
     expect(xButtons.length).toEqual(1);
-    const oButtons = screen.queryAllByText('o');
+    const oButtons = screen.queryAllByText('O');
     expect(oButtons.length).toEqual(0);
   });
 });
 
   
   describe.skip('Wave 3:  Winner tests', () => {
-    describe('Prints "Winner is x" when x wins', () => {
+    describe('Prints "The winner is X" when X wins', () => {
       test('that a winner will be identified when 3 Xs get in a row across the top', () => {
         // Arrange
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 0, 'x');
-        clickButtonAndVerifyResult(container, 3, 'o');
-        clickButtonAndVerifyResult(container, 2, 'x');
-        clickButtonAndVerifyResult(container, 4, 'o');
-        clickButtonAndVerifyResult(container, 1, 'x');
+        clickButtonAndVerifyResult(container, 0, 'X');
+        clickButtonAndVerifyResult(container, 3, 'O');
+        clickButtonAndVerifyResult(container, 2, 'X');
+        clickButtonAndVerifyResult(container, 4, 'O');
+        clickButtonAndVerifyResult(container, 1, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -109,14 +109,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 3, 'x');
-        clickButtonAndVerifyResult(container, 1, 'o');
-        clickButtonAndVerifyResult(container, 5, 'x');
-        clickButtonAndVerifyResult(container, 2, 'o');
-        clickButtonAndVerifyResult(container, 4, 'x');
+        clickButtonAndVerifyResult(container, 3, 'X');
+        clickButtonAndVerifyResult(container, 1, 'O');
+        clickButtonAndVerifyResult(container, 5, 'X');
+        clickButtonAndVerifyResult(container, 2, 'O');
+        clickButtonAndVerifyResult(container, 4, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -125,14 +125,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 6, 'x');
-        clickButtonAndVerifyResult(container, 1, 'o');
-        clickButtonAndVerifyResult(container, 8, 'x');
-        clickButtonAndVerifyResult(container, 2, 'o');
-        clickButtonAndVerifyResult(container, 7, 'x');
+        clickButtonAndVerifyResult(container, 6, 'X');
+        clickButtonAndVerifyResult(container, 1, 'O');
+        clickButtonAndVerifyResult(container, 8, 'X');
+        clickButtonAndVerifyResult(container, 2, 'O');
+        clickButtonAndVerifyResult(container, 7, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -142,14 +142,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 3, 'x');
-        clickButtonAndVerifyResult(container, 1, 'o');
-        clickButtonAndVerifyResult(container, 6, 'x');
-        clickButtonAndVerifyResult(container, 2, 'o');
-        clickButtonAndVerifyResult(container, 0, 'x');
+        clickButtonAndVerifyResult(container, 3, 'X');
+        clickButtonAndVerifyResult(container, 1, 'O');
+        clickButtonAndVerifyResult(container, 6, 'X');
+        clickButtonAndVerifyResult(container, 2, 'O');
+        clickButtonAndVerifyResult(container, 0, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -158,14 +158,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 4, 'x');
-        clickButtonAndVerifyResult(container, 0, 'o');
-        clickButtonAndVerifyResult(container, 7, 'x');
-        clickButtonAndVerifyResult(container, 2, 'o');
-        clickButtonAndVerifyResult(container, 1, 'x');
+        clickButtonAndVerifyResult(container, 4, 'X');
+        clickButtonAndVerifyResult(container, 0, 'O');
+        clickButtonAndVerifyResult(container, 7, 'X');
+        clickButtonAndVerifyResult(container, 2, 'O');
+        clickButtonAndVerifyResult(container, 1, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -174,14 +174,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 2, 'x');
-        clickButtonAndVerifyResult(container, 0, 'o');
-        clickButtonAndVerifyResult(container, 5, 'x');
-        clickButtonAndVerifyResult(container, 1, 'o');
-        clickButtonAndVerifyResult(container, 8, 'x');
+        clickButtonAndVerifyResult(container, 2, 'X');
+        clickButtonAndVerifyResult(container, 0, 'O');
+        clickButtonAndVerifyResult(container, 5, 'X');
+        clickButtonAndVerifyResult(container, 1, 'O');
+        clickButtonAndVerifyResult(container, 8, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -191,14 +191,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 0, 'x');
-        clickButtonAndVerifyResult(container, 1, 'o');
-        clickButtonAndVerifyResult(container, 4, 'x');
-        clickButtonAndVerifyResult(container, 2, 'o');
-        clickButtonAndVerifyResult(container, 8, 'x');
+        clickButtonAndVerifyResult(container, 0, 'X');
+        clickButtonAndVerifyResult(container, 1, 'O');
+        clickButtonAndVerifyResult(container, 4, 'X');
+        clickButtonAndVerifyResult(container, 2, 'O');
+        clickButtonAndVerifyResult(container, 8, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -207,14 +207,14 @@ describe('App', () => {
         const { container } = render(<App />);
 
         // Act
-        clickButtonAndVerifyResult(container, 2, 'x');
-        clickButtonAndVerifyResult(container, 0, 'o');
-        clickButtonAndVerifyResult(container, 4, 'x');
-        clickButtonAndVerifyResult(container, 3, 'o');
-        clickButtonAndVerifyResult(container, 6, 'x');
+        clickButtonAndVerifyResult(container, 2, 'X');
+        clickButtonAndVerifyResult(container, 0, 'O');
+        clickButtonAndVerifyResult(container, 4, 'X');
+        clickButtonAndVerifyResult(container, 3, 'O');
+        clickButtonAndVerifyResult(container, 6, 'X');
 
         // Assert
-        const winnerScreen = screen.queryByText('Winner is x')
+        const winnerScreen = screen.queryByText('The winner is X')
         expect(winnerScreen).not.toBeNull();
         expect(winnerScreen).toBeInTheDocument();
       });
@@ -222,21 +222,21 @@ describe('App', () => {
   });
 
 
-  describe('Prints "Winner is o" when o wins', () => {
+  describe('Prints "The winner is O" when o wins', () => {
     test('that a winner will be identified when 3 os get in a row across the top', () => {
       // Arrange
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 3, 'x');
-      clickButtonAndVerifyResult(container, 0, 'o');
-      clickButtonAndVerifyResult(container, 4, 'x');
-      clickButtonAndVerifyResult(container, 1, 'o');
-      clickButtonAndVerifyResult(container, 6, 'x');
-      clickButtonAndVerifyResult(container, 2, 'o');
+      clickButtonAndVerifyResult(container, 3, 'X');
+      clickButtonAndVerifyResult(container, 0, 'O');
+      clickButtonAndVerifyResult(container, 4, 'X');
+      clickButtonAndVerifyResult(container, 1, 'O');
+      clickButtonAndVerifyResult(container, 6, 'X');
+      clickButtonAndVerifyResult(container, 2, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });
@@ -246,15 +246,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 1, 'x');
-      clickButtonAndVerifyResult(container, 3, 'o');
-      clickButtonAndVerifyResult(container, 0, 'x');
-      clickButtonAndVerifyResult(container, 4, 'o');
-      clickButtonAndVerifyResult(container, 8, 'x');
-      clickButtonAndVerifyResult(container, 5, 'o');
+      clickButtonAndVerifyResult(container, 1, 'X');
+      clickButtonAndVerifyResult(container, 3, 'O');
+      clickButtonAndVerifyResult(container, 0, 'X');
+      clickButtonAndVerifyResult(container, 4, 'O');
+      clickButtonAndVerifyResult(container, 8, 'X');
+      clickButtonAndVerifyResult(container, 5, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });
@@ -263,15 +263,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 0, 'x');
-      clickButtonAndVerifyResult(container, 6, 'o');
-      clickButtonAndVerifyResult(container, 1, 'x');
-      clickButtonAndVerifyResult(container, 8, 'o');
-      clickButtonAndVerifyResult(container, 4, 'x');
-      clickButtonAndVerifyResult(container, 7, 'o');
+      clickButtonAndVerifyResult(container, 0, 'X');
+      clickButtonAndVerifyResult(container, 6, 'O');
+      clickButtonAndVerifyResult(container, 1, 'X');
+      clickButtonAndVerifyResult(container, 8, 'O');
+      clickButtonAndVerifyResult(container, 4, 'X');
+      clickButtonAndVerifyResult(container, 7, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });
@@ -281,15 +281,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 4, 'x');
-      clickButtonAndVerifyResult(container, 3, 'o');
-      clickButtonAndVerifyResult(container, 8, 'x');
-      clickButtonAndVerifyResult(container, 0, 'o');
-      clickButtonAndVerifyResult(container, 1, 'x');
-      clickButtonAndVerifyResult(container, 6, 'o');
+      clickButtonAndVerifyResult(container, 4, 'X');
+      clickButtonAndVerifyResult(container, 3, 'O');
+      clickButtonAndVerifyResult(container, 8, 'X');
+      clickButtonAndVerifyResult(container, 0, 'O');
+      clickButtonAndVerifyResult(container, 1, 'X');
+      clickButtonAndVerifyResult(container, 6, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });
@@ -298,15 +298,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 3, 'x');
-      clickButtonAndVerifyResult(container, 4, 'o');
-      clickButtonAndVerifyResult(container, 6, 'x');
-      clickButtonAndVerifyResult(container, 1, 'o');
-      clickButtonAndVerifyResult(container, 5, 'x');
-      clickButtonAndVerifyResult(container, 7, 'o');
+      clickButtonAndVerifyResult(container, 3, 'X');
+      clickButtonAndVerifyResult(container, 4, 'O');
+      clickButtonAndVerifyResult(container, 6, 'X');
+      clickButtonAndVerifyResult(container, 1, 'O');
+      clickButtonAndVerifyResult(container, 5, 'X');
+      clickButtonAndVerifyResult(container, 7, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });
@@ -315,15 +315,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 1, 'x');
-      clickButtonAndVerifyResult(container, 2, 'o');
-      clickButtonAndVerifyResult(container, 0, 'x');
-      clickButtonAndVerifyResult(container, 5, 'o');
-      clickButtonAndVerifyResult(container, 7, 'x');
-      clickButtonAndVerifyResult(container, 8, 'o');
+      clickButtonAndVerifyResult(container, 1, 'X');
+      clickButtonAndVerifyResult(container, 2, 'O');
+      clickButtonAndVerifyResult(container, 0, 'X');
+      clickButtonAndVerifyResult(container, 5, 'O');
+      clickButtonAndVerifyResult(container, 7, 'X');
+      clickButtonAndVerifyResult(container, 8, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });    
@@ -333,15 +333,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 1, 'x');
-      clickButtonAndVerifyResult(container, 0, 'o');
-      clickButtonAndVerifyResult(container, 3, 'x');
-      clickButtonAndVerifyResult(container, 4, 'o');
-      clickButtonAndVerifyResult(container, 7, 'x');
-      clickButtonAndVerifyResult(container, 8, 'o');
+      clickButtonAndVerifyResult(container, 1, 'X');
+      clickButtonAndVerifyResult(container, 0, 'O');
+      clickButtonAndVerifyResult(container, 3, 'X');
+      clickButtonAndVerifyResult(container, 4, 'O');
+      clickButtonAndVerifyResult(container, 7, 'X');
+      clickButtonAndVerifyResult(container, 8, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });  
@@ -350,15 +350,15 @@ describe('App', () => {
       const { container } = render(<App />);
 
       // Act
-      clickButtonAndVerifyResult(container, 0, 'x');
-      clickButtonAndVerifyResult(container, 2, 'o');
-      clickButtonAndVerifyResult(container, 3, 'x');
-      clickButtonAndVerifyResult(container, 4, 'o');
-      clickButtonAndVerifyResult(container, 7, 'x');
-      clickButtonAndVerifyResult(container, 6, 'o');
+      clickButtonAndVerifyResult(container, 0, 'X');
+      clickButtonAndVerifyResult(container, 2, 'O');
+      clickButtonAndVerifyResult(container, 3, 'X');
+      clickButtonAndVerifyResult(container, 4, 'O');
+      clickButtonAndVerifyResult(container, 7, 'X');
+      clickButtonAndVerifyResult(container, 6, 'O');
 
       // Assert
-      const winnerScreen = screen.queryByText('Winner is o')
+      const winnerScreen = screen.queryByText('The winner is O')
       expect(winnerScreen).not.toBeNull();
       expect(winnerScreen).toBeInTheDocument();
     });       
@@ -378,8 +378,8 @@ describe('App', () => {
     test('the button resets the game', () => {
       // Arrange - click on some squares
       const { container } = render(<App />);
-      clickButtonAndVerifyResult(container, 0, 'x');
-      clickButtonAndVerifyResult(container, 2, 'o');
+      clickButtonAndVerifyResult(container, 0, 'X');
+      clickButtonAndVerifyResult(container, 2, 'O');
 
       // Find the reset button
       const resetButton = screen.queryByText(/[Rr]eset\s+[Gg]ame/);
@@ -389,10 +389,10 @@ describe('App', () => {
 
       // Assert - There should no longer be Xs or Os 
       // on the board.
-      const xSquare = screen.queryByText('x');
+      const xSquare = screen.queryByText('X');
       expect(xSquare).toBeNull();
 
-      const oSquare = screen.queryByText('o');
+      const oSquare = screen.queryByText('O');
       expect(oSquare).toBeNull();
     });
   });


### PR DESCRIPTION
This PR fixes capitalization inconsistencies between the readme, provided code, and the tests.

I confirmed that the updated tests all pass with this solution: https://github.com/beccaelenzil/react-tic-tac-toe